### PR TITLE
include prism in reimagine2 for markdown syntax highlighting

### DIFF
--- a/app/assets/javascripts/reimagine2.js
+++ b/app/assets/javascripts/reimagine2.js
@@ -5,3 +5,4 @@
 //= require 'reimagine2/base'
 //= require 'reimagine2/accessible_custom_select'
 //= require 'responsive-tables'
+//= require 'prism'

--- a/app/assets/stylesheets/reimagine2.css.sass
+++ b/app/assets/stylesheets/reimagine2.css.sass
@@ -15,3 +15,4 @@
 @import 'reimagine2/fonts'
 
 @import 'responsive-tables'
+@import 'prism'

--- a/vendor/assets/javascripts/prism.js
+++ b/vendor/assets/javascripts/prism.js
@@ -1,0 +1,1049 @@
+/* http://prismjs.com/download.html?themes=prism&languages=markup+css+css-extras+clike+javascript+java+php+php-extras+coffeescript+scss+bash+c+python+sql+http+ruby+scala+haskell+swift+objectivec+latex+apacheconf+git */
+self = (typeof window !== 'undefined')
+  ? window   // if in browser
+  : (
+    (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope)
+    ? self // if in worker
+    : {}   // if in node js
+  );
+
+/**
+ * Prism: Lightweight, robust, elegant syntax highlighting
+ * MIT license http://www.opensource.org/licenses/mit-license.php/
+ * @author Lea Verou http://lea.verou.me
+ */
+
+var Prism = (function(){
+
+// Private helper vars
+var lang = /\blang(?:uage)?-(?!\*)(\w+)\b/i;
+
+var _ = self.Prism = {
+  util: {
+    encode: function (tokens) {
+      if (tokens instanceof Token) {
+        return new Token(tokens.type, _.util.encode(tokens.content), tokens.alias);
+      } else if (_.util.type(tokens) === 'Array') {
+        return tokens.map(_.util.encode);
+      } else {
+        return tokens.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\u00a0/g, ' ');
+      }
+    },
+
+    type: function (o) {
+      return Object.prototype.toString.call(o).match(/\[object (\w+)\]/)[1];
+    },
+
+    // Deep clone a language definition (e.g. to extend it)
+    clone: function (o) {
+      var type = _.util.type(o);
+
+      switch (type) {
+        case 'Object':
+          var clone = {};
+
+          for (var key in o) {
+            if (o.hasOwnProperty(key)) {
+              clone[key] = _.util.clone(o[key]);
+            }
+          }
+
+          return clone;
+
+        case 'Array':
+          return o.slice();
+      }
+
+      return o;
+    }
+  },
+
+  languages: {
+    extend: function (id, redef) {
+      var lang = _.util.clone(_.languages[id]);
+
+      for (var key in redef) {
+        lang[key] = redef[key];
+      }
+
+      return lang;
+    },
+
+    // Insert a token before another token in a language literal
+    insertBefore: function (inside, before, insert, root) {
+      root = root || _.languages;
+      var grammar = root[inside];
+      var ret = {};
+
+      for (var token in grammar) {
+
+        if (grammar.hasOwnProperty(token)) {
+
+          if (token == before) {
+
+            for (var newToken in insert) {
+
+              if (insert.hasOwnProperty(newToken)) {
+                ret[newToken] = insert[newToken];
+              }
+            }
+          }
+
+          ret[token] = grammar[token];
+        }
+      }
+
+      return root[inside] = ret;
+    },
+
+    // Traverse a language definition with Depth First Search
+    DFS: function(o, callback, type) {
+      for (var i in o) {
+        if (o.hasOwnProperty(i)) {
+          callback.call(o, i, o[i], type || i);
+
+          if (_.util.type(o[i]) === 'Object') {
+            _.languages.DFS(o[i], callback);
+          } else if (_.util.type(o[i]) === 'Array') {
+            _.languages.DFS(o[i], callback, i);
+          }
+        }
+      }
+    }
+  },
+
+  highlightAll: function(async, callback) {
+    var elements = document.querySelectorAll('code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code');
+
+    for (var i=0, element; element = elements[i++];) {
+      _.highlightElement(element, async === true, callback);
+    }
+  },
+
+  highlightElement: function(element, async, callback) {
+    // Find language
+    var language, grammar, parent = element;
+
+    while (parent && !lang.test(parent.className)) {
+      parent = parent.parentNode;
+    }
+
+    if (parent) {
+      language = (parent.className.match(lang) || [,''])[1];
+      grammar = _.languages[language];
+    }
+
+    if (!grammar) {
+      return;
+    }
+
+    // Set language on the element, if not present
+    element.className = element.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+
+    // Set language on the parent, for styling
+    parent = element.parentNode;
+
+    if (/pre/i.test(parent.nodeName)) {
+      parent.className = parent.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
+    }
+
+    var code = element.textContent;
+
+    if(!code) {
+      return;
+    }
+
+    var env = {
+      element: element,
+      language: language,
+      grammar: grammar,
+      code: code
+    };
+
+    _.hooks.run('before-highlight', env);
+
+    if (async && self.Worker) {
+      var worker = new Worker(_.filename);
+
+      worker.onmessage = function(evt) {
+        env.highlightedCode = Token.stringify(JSON.parse(evt.data), language);
+
+        _.hooks.run('before-insert', env);
+
+        env.element.innerHTML = env.highlightedCode;
+
+        callback && callback.call(env.element);
+        _.hooks.run('after-highlight', env);
+      };
+
+      worker.postMessage(JSON.stringify({
+        language: env.language,
+        code: env.code
+      }));
+    }
+    else {
+      env.highlightedCode = _.highlight(env.code, env.grammar, env.language)
+
+      _.hooks.run('before-insert', env);
+
+      env.element.innerHTML = env.highlightedCode;
+
+      callback && callback.call(element);
+
+      _.hooks.run('after-highlight', env);
+    }
+  },
+
+  highlight: function (text, grammar, language) {
+    var tokens = _.tokenize(text, grammar);
+    return Token.stringify(_.util.encode(tokens), language);
+  },
+
+  tokenize: function(text, grammar, language) {
+    var Token = _.Token;
+
+    var strarr = [text];
+
+    var rest = grammar.rest;
+
+    if (rest) {
+      for (var token in rest) {
+        grammar[token] = rest[token];
+      }
+
+      delete grammar.rest;
+    }
+
+    tokenloop: for (var token in grammar) {
+      if(!grammar.hasOwnProperty(token) || !grammar[token]) {
+        continue;
+      }
+
+      var patterns = grammar[token];
+      patterns = (_.util.type(patterns) === "Array") ? patterns : [patterns];
+
+      for (var j = 0; j < patterns.length; ++j) {
+        var pattern = patterns[j],
+          inside = pattern.inside,
+          lookbehind = !!pattern.lookbehind,
+          lookbehindLength = 0,
+          alias = pattern.alias;
+
+        pattern = pattern.pattern || pattern;
+
+        for (var i=0; i<strarr.length; i++) { // Don’t cache length as it changes during the loop
+
+          var str = strarr[i];
+
+          if (strarr.length > text.length) {
+            // Something went terribly wrong, ABORT, ABORT!
+            break tokenloop;
+          }
+
+          if (str instanceof Token) {
+            continue;
+          }
+
+          pattern.lastIndex = 0;
+
+          var match = pattern.exec(str);
+
+          if (match) {
+            if(lookbehind) {
+              lookbehindLength = match[1].length;
+            }
+
+            var from = match.index - 1 + lookbehindLength,
+              match = match[0].slice(lookbehindLength),
+              len = match.length,
+              to = from + len,
+              before = str.slice(0, from + 1),
+              after = str.slice(to + 1);
+
+            var args = [i, 1];
+
+            if (before) {
+              args.push(before);
+            }
+
+            var wrapped = new Token(token, inside? _.tokenize(match, inside) : match, alias);
+
+            args.push(wrapped);
+
+            if (after) {
+              args.push(after);
+            }
+
+            Array.prototype.splice.apply(strarr, args);
+          }
+        }
+      }
+    }
+
+    return strarr;
+  },
+
+  hooks: {
+    all: {},
+
+    add: function (name, callback) {
+      var hooks = _.hooks.all;
+
+      hooks[name] = hooks[name] || [];
+
+      hooks[name].push(callback);
+    },
+
+    run: function (name, env) {
+      var callbacks = _.hooks.all[name];
+
+      if (!callbacks || !callbacks.length) {
+        return;
+      }
+
+      for (var i=0, callback; callback = callbacks[i++];) {
+        callback(env);
+      }
+    }
+  }
+};
+
+var Token = _.Token = function(type, content, alias) {
+  this.type = type;
+  this.content = content;
+  this.alias = alias;
+};
+
+Token.stringify = function(o, language, parent) {
+  if (typeof o == 'string') {
+    return o;
+  }
+
+  if (Object.prototype.toString.call(o) == '[object Array]') {
+    return o.map(function(element) {
+      return Token.stringify(element, language, o);
+    }).join('');
+  }
+
+  var env = {
+    type: o.type,
+    content: Token.stringify(o.content, language, parent),
+    tag: 'span',
+    classes: ['token', o.type],
+    attributes: {},
+    language: language,
+    parent: parent
+  };
+
+  if (env.type == 'comment') {
+    env.attributes['spellcheck'] = 'true';
+  }
+
+  if (o.alias) {
+    var aliases = _.util.type(o.alias) === 'Array' ? o.alias : [o.alias];
+    Array.prototype.push.apply(env.classes, aliases);
+  }
+
+  _.hooks.run('wrap', env);
+
+  var attributes = '';
+
+  for (var name in env.attributes) {
+    attributes += name + '="' + (env.attributes[name] || '') + '"';
+  }
+
+  return '<' + env.tag + ' class="' + env.classes.join(' ') + '" ' + attributes + '>' + env.content + '</' + env.tag + '>';
+
+};
+
+if (!self.document) {
+  if (!self.addEventListener) {
+    // in Node.js
+    return self.Prism;
+  }
+  // In worker
+  self.addEventListener('message', function(evt) {
+    var message = JSON.parse(evt.data),
+        lang = message.language,
+        code = message.code;
+
+    self.postMessage(JSON.stringify(_.util.encode(_.tokenize(code, _.languages[lang]))));
+    self.close();
+  }, false);
+
+  return self.Prism;
+}
+
+// Get current script and highlight
+var script = document.getElementsByTagName('script');
+
+script = script[script.length - 1];
+
+if (script) {
+  _.filename = script.src;
+
+  if (document.addEventListener && !script.hasAttribute('data-manual')) {
+    document.addEventListener('DOMContentLoaded', _.highlightAll);
+  }
+}
+
+return self.Prism;
+
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = Prism;
+}
+;
+Prism.languages.markup = {
+  'comment': /<!--[\w\W]*?-->/g,
+  'prolog': /<\?.+?\?>/,
+  'doctype': /<!DOCTYPE.+?>/,
+  'cdata': /<!\[CDATA\[[\w\W]*?]]>/i,
+  'tag': {
+    pattern: /<\/?[\w:-]+\s*(?:\s+[\w:-]+(?:=(?:("|')(\\?[\w\W])*?\1|[^\s'">=]+))?\s*)*\/?>/gi,
+    inside: {
+      'tag': {
+        pattern: /^<\/?[\w:-]+/i,
+        inside: {
+          'punctuation': /^<\/?/,
+          'namespace': /^[\w-]+?:/
+        }
+      },
+      'attr-value': {
+        pattern: /=(?:('|")[\w\W]*?(\1)|[^\s>]+)/gi,
+        inside: {
+          'punctuation': /=|>|"/g
+        }
+      },
+      'punctuation': /\/?>/g,
+      'attr-name': {
+        pattern: /[\w:-]+/g,
+        inside: {
+          'namespace': /^[\w-]+?:/
+        }
+      }
+
+    }
+  },
+  'entity': /\&#?[\da-z]{1,8};/gi
+};
+
+// Plugin to make entity title show the real entity, idea by Roman Komarov
+Prism.hooks.add('wrap', function(env) {
+
+  if (env.type === 'entity') {
+    env.attributes['title'] = env.content.replace(/&amp;/, '&');
+  }
+});
+;
+Prism.languages.css = {
+  'comment': /\/\*[\w\W]*?\*\//g,
+  'atrule': {
+    pattern: /@[\w-]+?.*?(;|(?=\s*{))/gi,
+    inside: {
+      'punctuation': /[;:]/g
+    }
+  },
+  'url': /url\((["']?).*?\1\)/gi,
+  'selector': /[^\{\}\s][^\{\};]*(?=\s*\{)/g,
+  'property': /(\b|\B)[\w-]+(?=\s*:)/ig,
+  'string': /("|')(\\?.)*?\1/g,
+  'important': /\B!important\b/gi,
+  'punctuation': /[\{\};:]/g,
+  'function': /[-a-z0-9]+(?=\()/ig
+};
+
+if (Prism.languages.markup) {
+  Prism.languages.insertBefore('markup', 'tag', {
+    'style': {
+      pattern: /<style[\w\W]*?>[\w\W]*?<\/style>/ig,
+      inside: {
+        'tag': {
+          pattern: /<style[\w\W]*?>|<\/style>/ig,
+          inside: Prism.languages.markup.tag.inside
+        },
+        rest: Prism.languages.css
+      }
+    }
+  });
+};
+Prism.languages.css.selector = {
+  pattern: /[^\{\}\s][^\{\}]*(?=\s*\{)/g,
+  inside: {
+    'pseudo-element': /:(?:after|before|first-letter|first-line|selection)|::[-\w]+/g,
+    'pseudo-class': /:[-\w]+(?:\(.*\))?/g,
+    'class': /\.[-:\.\w]+/g,
+    'id': /#[-:\.\w]+/g
+  }
+};
+
+Prism.languages.insertBefore('css', 'ignore', {
+  'hexcode': /#[\da-f]{3,6}/gi,
+  'entity': /\\[\da-f]{1,8}/gi,
+  'number': /[\d%\.]+/g
+});;
+Prism.languages.clike = {
+  'comment': [
+    {
+      pattern: /(^|[^\\])\/\*[\w\W]*?\*\//g,
+      lookbehind: true
+    },
+    {
+      pattern: /(^|[^\\:])\/\/.*?(\r?\n|$)/g,
+      lookbehind: true
+    }
+  ],
+  'string': /("|')(\\?.)*?\1/g,
+  'class-name': {
+    pattern: /((?:(?:class|interface|extends|implements|trait|instanceof|new)\s+)|(?:catch\s+\())[a-z0-9_\.\\]+/ig,
+    lookbehind: true,
+    inside: {
+      punctuation: /(\.|\\)/
+    }
+  },
+  'keyword': /\b(if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\b/g,
+  'boolean': /\b(true|false)\b/g,
+  'function': {
+    pattern: /[a-z0-9_]+\(/ig,
+    inside: {
+      punctuation: /\(/
+    }
+  },
+  'number': /\b-?(0x[\dA-Fa-f]+|\d*\.?\d+([Ee]-?\d+)?)\b/g,
+  'operator': /[-+]{1,2}|!|<=?|>=?|={1,3}|&{1,2}|\|?\||\?|\*|\/|\~|\^|\%/g,
+  'ignore': /&(lt|gt|amp);/gi,
+  'punctuation': /[{}[\];(),.:]/g
+};
+;
+Prism.languages.javascript = Prism.languages.extend('clike', {
+  'keyword': /\b(break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|get|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|set|static|super|switch|this|throw|true|try|typeof|var|void|while|with|yield)\b/g,
+  'number': /\b-?(0x[\dA-Fa-f]+|\d*\.?\d+([Ee]-?\d+)?|NaN|-?Infinity)\b/g
+});
+
+Prism.languages.insertBefore('javascript', 'keyword', {
+  'regex': {
+    pattern: /(^|[^/])\/(?!\/)(\[.+?]|\\.|[^/\r\n])+\/[gim]{0,3}(?=\s*($|[\r\n,.;})]))/g,
+    lookbehind: true
+  }
+});
+
+if (Prism.languages.markup) {
+  Prism.languages.insertBefore('markup', 'tag', {
+    'script': {
+      pattern: /<script[\w\W]*?>[\w\W]*?<\/script>/ig,
+      inside: {
+        'tag': {
+          pattern: /<script[\w\W]*?>|<\/script>/ig,
+          inside: Prism.languages.markup.tag.inside
+        },
+        rest: Prism.languages.javascript
+      }
+    }
+  });
+}
+;
+Prism.languages.java = Prism.languages.extend('clike', {
+  'keyword': /\b(abstract|continue|for|new|switch|assert|default|goto|package|synchronized|boolean|do|if|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while)\b/g,
+  'number': /\b0b[01]+\b|\b0x[\da-f]*\.?[\da-fp\-]+\b|\b\d*\.?\d+[e]?[\d]*[df]\b|\W\d*\.?\d+\b/gi,
+  'operator': {
+    pattern: /(^|[^\.])(?:\+=|\+\+?|-=|--?|!=?|<{1,2}=?|>{1,3}=?|==?|&=|&&?|\|=|\|\|?|\?|\*=?|\/=?|%=?|\^=?|:|~)/gm,
+    lookbehind: true
+  }
+});;
+/**
+ * Original by Aaron Harun: http://aahacreative.com/2012/07/31/php-syntax-highlighting-prism/
+ * Modified by Miles Johnson: http://milesj.me
+ *
+ * Supports the following:
+ *    - Extends clike syntax
+ *    - Support for PHP 5.3+ (namespaces, traits, generators, etc)
+ *    - Smarter constant and function matching
+ *
+ * Adds the following new token classes:
+ *    constant, delimiter, variable, function, package
+ */
+
+Prism.languages.php = Prism.languages.extend('clike', {
+  'keyword': /\b(and|or|xor|array|as|break|case|cfunction|class|const|continue|declare|default|die|do|else|elseif|enddeclare|endfor|endforeach|endif|endswitch|endwhile|extends|for|foreach|function|include|include_once|global|if|new|return|static|switch|use|require|require_once|var|while|abstract|interface|public|implements|private|protected|parent|throw|null|echo|print|trait|namespace|final|yield|goto|instanceof|finally|try|catch)\b/ig,
+  'constant': /\b[A-Z0-9_]{2,}\b/g,
+  'comment': {
+    pattern: /(^|[^\\])(\/\*[\w\W]*?\*\/|(^|[^:])(\/\/|#).*?(\r?\n|$))/g,
+    lookbehind: true
+  }
+});
+
+Prism.languages.insertBefore('php', 'keyword', {
+  'delimiter': /(\?>|<\?php|<\?)/ig,
+  'variable': /(\$\w+)\b/ig,
+  'package': {
+    pattern: /(\\|namespace\s+|use\s+)[\w\\]+/g,
+    lookbehind: true,
+    inside: {
+      punctuation: /\\/
+    }
+  }
+});
+
+// Must be defined after the function pattern
+Prism.languages.insertBefore('php', 'operator', {
+  'property': {
+    pattern: /(->)[\w]+/g,
+    lookbehind: true
+  }
+});
+
+// Add HTML support of the markup language exists
+if (Prism.languages.markup) {
+
+  // Tokenize all inline PHP blocks that are wrapped in <?php ?>
+  // This allows for easy PHP + markup highlighting
+  Prism.hooks.add('before-highlight', function(env) {
+    if (env.language !== 'php') {
+      return;
+    }
+
+    env.tokenStack = [];
+
+    env.backupCode = env.code;
+    env.code = env.code.replace(/(?:<\?php|<\?)[\w\W]*?(?:\?>)/ig, function(match) {
+      env.tokenStack.push(match);
+
+      return '{{{PHP' + env.tokenStack.length + '}}}';
+    });
+  });
+
+  // Restore env.code for other plugins (e.g. line-numbers)
+  Prism.hooks.add('before-insert', function(env) {
+    if (env.language === 'php') {
+      env.code = env.backupCode;
+      delete env.backupCode;
+    }
+  });
+
+  // Re-insert the tokens after highlighting
+  Prism.hooks.add('after-highlight', function(env) {
+    if (env.language !== 'php') {
+      return;
+    }
+
+    for (var i = 0, t; t = env.tokenStack[i]; i++) {
+      env.highlightedCode = env.highlightedCode.replace('{{{PHP' + (i + 1) + '}}}', Prism.highlight(t, env.grammar, 'php'));
+    }
+
+    env.element.innerHTML = env.highlightedCode;
+  });
+
+  // Wrap tokens in classes that are missing them
+  Prism.hooks.add('wrap', function(env) {
+    if (env.language === 'php' && env.type === 'markup') {
+      env.content = env.content.replace(/(\{\{\{PHP[0-9]+\}\}\})/g, "<span class=\"token php\">$1</span>");
+    }
+  });
+
+  // Add the rules before all others
+  Prism.languages.insertBefore('php', 'comment', {
+    'markup': {
+      pattern: /<[^?]\/?(.*?)>/g,
+      inside: Prism.languages.markup
+    },
+    'php': /\{\{\{PHP[0-9]+\}\}\}/g
+  });
+}
+;
+Prism.languages.insertBefore('php', 'variable', {
+  'this': /\$this/g,
+  'global': /\$_?(GLOBALS|SERVER|GET|POST|FILES|REQUEST|SESSION|ENV|COOKIE|HTTP_RAW_POST_DATA|argc|argv|php_errormsg|http_response_header)/g,
+  'scope': {
+    pattern: /\b[\w\\]+::/g,
+    inside: {
+      keyword: /(static|self|parent)/,
+      punctuation: /(::|\\)/
+    }
+  }
+});;
+Prism.languages.coffeescript = Prism.languages.extend('javascript', {
+  'comment': [
+    /([#]{3}\s*\r?\n(.*\s*\r*\n*)\s*?\r?\n[#]{3})/g,
+    /(\s|^)([#]{1}[^#^\r^\n]{2,}?(\r?\n|$))/g
+  ],
+  'keyword': /\b(this|window|delete|class|extends|namespace|extend|ar|let|if|else|while|do|for|each|of|return|in|instanceof|new|with|typeof|try|catch|finally|null|undefined|break|continue)\b/g
+});
+
+Prism.languages.insertBefore('coffeescript', 'keyword', {
+  'function': {
+    pattern: /[a-z|A-z]+\s*[:|=]\s*(\([.|a-z\s|,|:|{|}|\"|\'|=]*\))?\s*-&gt;/gi,
+    inside: {
+      'function-name': /[_?a-z-|A-Z-]+(\s*[:|=])| @[_?$?a-z-|A-Z-]+(\s*)| /g,
+      'operator': /[-+]{1,2}|!|=?&lt;|=?&gt;|={1,2}|(&amp;){1,2}|\|?\||\?|\*|\//g
+    }
+  },
+  'attr-name': /[_?a-z-|A-Z-]+(\s*:)| @[_?$?a-z-|A-Z-]+(\s*)| /g
+});
+;
+Prism.languages.scss = Prism.languages.extend('css', {
+  'comment': {
+    pattern: /(^|[^\\])(\/\*[\w\W]*?\*\/|\/\/.*?(\r?\n|$))/g,
+    lookbehind: true
+  },
+  // aturle is just the @***, not the entire rule (to highlight var & stuffs)
+  // + add ability to highlight number & unit for media queries
+  'atrule': /@[\w-]+(?=\s+(\(|\{|;))/gi,
+  // url, compassified
+  'url': /([-a-z]+-)*url(?=\()/gi,
+  // CSS selector regex is not appropriate for Sass
+  // since there can be lot more things (var, @ directive, nesting..)
+  // a selector must start at the end of a property or after a brace (end of other rules or nesting)
+  // it can contain some caracters that aren't used for defining rules or end of selector, & (parent selector), or interpolated variable
+  // the end of a selector is found when there is no rules in it ( {} or {\s}) or if there is a property (because an interpolated var
+  // can "pass" as a selector- e.g: proper#{$erty})
+  // this one was ard to do, so please be careful if you edit this one :)
+  'selector': /([^@;\{\}\(\)]?([^@;\{\}\(\)]|&|\#\{\$[-_\w]+\})+)(?=\s*\{(\}|\s|[^\}]+(:|\{)[^\}]+))/gm
+});
+
+Prism.languages.insertBefore('scss', 'atrule', {
+  'keyword': /@(if|else if|else|for|each|while|import|extend|debug|warn|mixin|include|function|return|content)|(?=@for\s+\$[-_\w]+\s)+from/i
+});
+
+Prism.languages.insertBefore('scss', 'property', {
+  // var and interpolated vars
+  'variable': /((\$[-_\w]+)|(#\{\$[-_\w]+\}))/i
+});
+
+Prism.languages.insertBefore('scss', 'ignore', {
+  'placeholder': /%[-_\w]+/i,
+  'statement': /\B!(default|optional)\b/gi,
+  'boolean': /\b(true|false)\b/g,
+  'null': /\b(null)\b/g,
+  'operator': /\s+([-+]{1,2}|={1,2}|!=|\|?\||\?|\*|\/|\%)\s+/g
+});
+;
+Prism.languages.bash = Prism.languages.extend('clike', {
+  'comment': {
+    pattern: /(^|[^"{\\])(#.*?(\r?\n|$))/g,
+    lookbehind: true
+  },
+  'string': {
+    //allow multiline string
+    pattern: /("|')(\\?[\s\S])*?\1/g,
+    inside: {
+      //'property' class reused for bash variables
+      'property': /\$([a-zA-Z0-9_#\?\-\*!@]+|\{[^\}]+\})/g
+    }
+  },
+  'keyword': /\b(if|then|else|elif|fi|for|break|continue|while|in|case|function|select|do|done|until|echo|exit|return|set|declare)\b/g
+});
+
+Prism.languages.insertBefore('bash', 'keyword', {
+  //'property' class reused for bash variables
+  'property': /\$([a-zA-Z0-9_#\?\-\*!@]+|\{[^}]+\})/g
+});
+Prism.languages.insertBefore('bash', 'comment', {
+  //shebang must be before comment, 'important' class from css reused
+  'important': /(^#!\s*\/bin\/bash)|(^#!\s*\/bin\/sh)/g
+});
+;
+Prism.languages.c = Prism.languages.extend('clike', {
+  // allow for c multiline strings
+  'string': /("|')([^\n\\\1]|\\.|\\\r*\n)*?\1/g,
+  'keyword': /\b(asm|typeof|inline|auto|break|case|char|const|continue|default|do|double|else|enum|extern|float|for|goto|if|int|long|register|return|short|signed|sizeof|static|struct|switch|typedef|union|unsigned|void|volatile|while)\b/g,
+  'operator': /[-+]{1,2}|!=?|<{1,2}=?|>{1,2}=?|\->|={1,2}|\^|~|%|&{1,2}|\|?\||\?|\*|\//g
+});
+
+Prism.languages.insertBefore('c', 'string', {
+  // property class reused for macro statements
+  'property': {
+    // allow for multiline macro definitions
+    // spaces after the # character compile fine with gcc
+    pattern: /((^|\n)\s*)#\s*[a-z]+([^\n\\]|\\.|\\\r*\n)*/gi,
+    lookbehind: true,
+    inside: {
+      // highlight the path of the include statement as a string
+      'string': {
+        pattern: /(#\s*include\s*)(<.+?>|("|')(\\?.)+?\3)/g,
+        lookbehind: true,
+      }
+    }
+  }
+});
+
+delete Prism.languages.c['class-name'];
+delete Prism.languages.c['boolean'];;
+Prism.languages.python= {
+  'comment': {
+    pattern: /(^|[^\\])#.*?(\r?\n|$)/g,
+    lookbehind: true
+  },
+  'string': /"""[\s\S]+?"""|("|')(\\?.)*?\1/g,
+  'keyword' : /\b(as|assert|break|class|continue|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|pass|print|raise|return|try|while|with|yield)\b/g,
+  'boolean' : /\b(True|False)\b/g,
+  'number' : /\b-?(0x)?\d*\.?[\da-f]+\b/g,
+  'operator' : /[-+]{1,2}|=?&lt;|=?&gt;|!|={1,2}|(&){1,2}|(&amp;){1,2}|\|?\||\?|\*|\/|~|\^|%|\b(or|and|not)\b/g,
+  'ignore' : /&(lt|gt|amp);/gi,
+  'punctuation' : /[{}[\];(),.:]/g
+};
+
+;
+Prism.languages.sql= {
+  'comment': {
+    pattern: /(^|[^\\])(\/\*[\w\W]*?\*\/|((--)|(\/\/)|#).*?(\r?\n|$))/g,
+    lookbehind: true
+  },
+  'string' : {
+    pattern: /(^|[^@])("|')(\\?[\s\S])*?\2/g,
+    lookbehind: true
+  },
+  'variable': /@[\w.$]+|@("|'|`)(\\?[\s\S])+?\1/g,
+  'function': /\b(?:COUNT|SUM|AVG|MIN|MAX|FIRST|LAST|UCASE|LCASE|MID|LEN|ROUND|NOW|FORMAT)(?=\s*\()/ig, // Should we highlight user defined functions too?
+  'keyword': /\b(?:ACTION|ADD|AFTER|ALGORITHM|ALTER|ANALYZE|APPLY|AS|ASC|AUTHORIZATION|BACKUP|BDB|BEGIN|BERKELEYDB|BIGINT|BINARY|BIT|BLOB|BOOL|BOOLEAN|BREAK|BROWSE|BTREE|BULK|BY|CALL|CASCADE|CASCADED|CASE|CHAIN|CHAR VARYING|CHARACTER VARYING|CHECK|CHECKPOINT|CLOSE|CLUSTERED|COALESCE|COLUMN|COLUMNS|COMMENT|COMMIT|COMMITTED|COMPUTE|CONNECT|CONSISTENT|CONSTRAINT|CONTAINS|CONTAINSTABLE|CONTINUE|CONVERT|CREATE|CROSS|CURRENT|CURRENT_DATE|CURRENT_TIME|CURRENT_TIMESTAMP|CURRENT_USER|CURSOR|DATA|DATABASE|DATABASES|DATETIME|DBCC|DEALLOCATE|DEC|DECIMAL|DECLARE|DEFAULT|DEFINER|DELAYED|DELETE|DENY|DESC|DESCRIBE|DETERMINISTIC|DISABLE|DISCARD|DISK|DISTINCT|DISTINCTROW|DISTRIBUTED|DO|DOUBLE|DOUBLE PRECISION|DROP|DUMMY|DUMP|DUMPFILE|DUPLICATE KEY|ELSE|ENABLE|ENCLOSED BY|END|ENGINE|ENUM|ERRLVL|ERRORS|ESCAPE|ESCAPED BY|EXCEPT|EXEC|EXECUTE|EXIT|EXPLAIN|EXTENDED|FETCH|FIELDS|FILE|FILLFACTOR|FIRST|FIXED|FLOAT|FOLLOWING|FOR|FOR EACH ROW|FORCE|FOREIGN|FREETEXT|FREETEXTTABLE|FROM|FULL|FUNCTION|GEOMETRY|GEOMETRYCOLLECTION|GLOBAL|GOTO|GRANT|GROUP|HANDLER|HASH|HAVING|HOLDLOCK|IDENTITY|IDENTITY_INSERT|IDENTITYCOL|IF|IGNORE|IMPORT|INDEX|INFILE|INNER|INNODB|INOUT|INSERT|INT|INTEGER|INTERSECT|INTO|INVOKER|ISOLATION LEVEL|JOIN|KEY|KEYS|KILL|LANGUAGE SQL|LAST|LEFT|LIMIT|LINENO|LINES|LINESTRING|LOAD|LOCAL|LOCK|LONGBLOB|LONGTEXT|MATCH|MATCHED|MEDIUMBLOB|MEDIUMINT|MEDIUMTEXT|MERGE|MIDDLEINT|MODIFIES SQL DATA|MODIFY|MULTILINESTRING|MULTIPOINT|MULTIPOLYGON|NATIONAL|NATIONAL CHAR VARYING|NATIONAL CHARACTER|NATIONAL CHARACTER VARYING|NATIONAL VARCHAR|NATURAL|NCHAR|NCHAR VARCHAR|NEXT|NO|NO SQL|NOCHECK|NOCYCLE|NONCLUSTERED|NULLIF|NUMERIC|OF|OFF|OFFSETS|ON|OPEN|OPENDATASOURCE|OPENQUERY|OPENROWSET|OPTIMIZE|OPTION|OPTIONALLY|ORDER|OUT|OUTER|OUTFILE|OVER|PARTIAL|PARTITION|PERCENT|PIVOT|PLAN|POINT|POLYGON|PRECEDING|PRECISION|PREV|PRIMARY|PRINT|PRIVILEGES|PROC|PROCEDURE|PUBLIC|PURGE|QUICK|RAISERROR|READ|READS SQL DATA|READTEXT|REAL|RECONFIGURE|REFERENCES|RELEASE|RENAME|REPEATABLE|REPLICATION|REQUIRE|RESTORE|RESTRICT|RETURN|RETURNS|REVOKE|RIGHT|ROLLBACK|ROUTINE|ROWCOUNT|ROWGUIDCOL|ROWS?|RTREE|RULE|SAVE|SAVEPOINT|SCHEMA|SELECT|SERIAL|SERIALIZABLE|SESSION|SESSION_USER|SET|SETUSER|SHARE MODE|SHOW|SHUTDOWN|SIMPLE|SMALLINT|SNAPSHOT|SOME|SONAME|START|STARTING BY|STATISTICS|STATUS|STRIPED|SYSTEM_USER|TABLE|TABLES|TABLESPACE|TEMP(?:ORARY)?|TEMPTABLE|TERMINATED BY|TEXT|TEXTSIZE|THEN|TIMESTAMP|TINYBLOB|TINYINT|TINYTEXT|TO|TOP|TRAN|TRANSACTION|TRANSACTIONS|TRIGGER|TRUNCATE|TSEQUAL|TYPE|TYPES|UNBOUNDED|UNCOMMITTED|UNDEFINED|UNION|UNPIVOT|UPDATE|UPDATETEXT|USAGE|USE|USER|USING|VALUE|VALUES|VARBINARY|VARCHAR|VARCHARACTER|VARYING|VIEW|WAITFOR|WARNINGS|WHEN|WHERE|WHILE|WITH|WITH ROLLUP|WITHIN|WORK|WRITE|WRITETEXT)\b/gi,
+  'boolean': /\b(?:TRUE|FALSE|NULL)\b/gi,
+  'number': /\b-?(0x)?\d*\.?[\da-f]+\b/g,
+  'operator': /\b(?:ALL|AND|ANY|BETWEEN|EXISTS|IN|LIKE|NOT|OR|IS|UNIQUE|CHARACTER SET|COLLATE|DIV|OFFSET|REGEXP|RLIKE|SOUNDS LIKE|XOR)\b|[-+]{1}|!|[=<>]{1,2}|(&){1,2}|\|?\||\?|\*|\//gi,
+  'punctuation': /[;[\]()`,.]/g
+};;
+Prism.languages.http = {
+    'request-line': {
+        pattern: /^(POST|GET|PUT|DELETE|OPTIONS|PATCH|TRACE|CONNECT)\b\shttps?:\/\/\S+\sHTTP\/[0-9.]+/g,
+        inside: {
+            // HTTP Verb
+            property: /^\b(POST|GET|PUT|DELETE|OPTIONS|PATCH|TRACE|CONNECT)\b/g,
+            // Path or query argument
+            'attr-name': /:\w+/g
+        }
+    },
+    'response-status': {
+        pattern: /^HTTP\/1.[01] [0-9]+.*/g,
+        inside: {
+            // Status, e.g. 200 OK
+            property: /[0-9]+[A-Z\s-]+$/g
+        }
+    },
+    // HTTP header name
+    keyword: /^[\w-]+:(?=.+)/gm
+};
+
+// Create a mapping of Content-Type headers to language definitions
+var httpLanguages = {
+    'application/json': Prism.languages.javascript,
+    'application/xml': Prism.languages.markup,
+    'text/xml': Prism.languages.markup,
+    'text/html': Prism.languages.markup
+};
+
+// Insert each content type parser that has its associated language
+// currently loaded.
+for (var contentType in httpLanguages) {
+    if (httpLanguages[contentType]) {
+        var options = {};
+        options[contentType] = {
+            pattern: new RegExp('(content-type:\\s*' + contentType + '[\\w\\W]*?)\\n\\n[\\w\\W]*', 'gi'),
+            lookbehind: true,
+            inside: {
+                rest: httpLanguages[contentType]
+            }
+        };
+        Prism.languages.insertBefore('http', 'keyword', options);
+    }
+}
+;
+/**
+ * Original by Samuel Flores
+ *
+ * Adds the following new token classes:
+ *    constant, builtin, variable, symbol, regex
+ */
+Prism.languages.ruby = Prism.languages.extend('clike', {
+  'comment': /#[^\r\n]*(\r?\n|$)/g,
+  'keyword': /\b(alias|and|BEGIN|begin|break|case|class|def|define_method|defined|do|each|else|elsif|END|end|ensure|false|for|if|in|module|new|next|nil|not|or|raise|redo|require|rescue|retry|return|self|super|then|throw|true|undef|unless|until|when|while|yield)\b/g,
+  'builtin': /\b(Array|Bignum|Binding|Class|Continuation|Dir|Exception|FalseClass|File|Stat|File|Fixnum|Fload|Hash|Integer|IO|MatchData|Method|Module|NilClass|Numeric|Object|Proc|Range|Regexp|String|Struct|TMS|Symbol|ThreadGroup|Thread|Time|TrueClass)\b/,
+  'constant': /\b[A-Z][a-zA-Z_0-9]*[?!]?\b/g
+});
+
+Prism.languages.insertBefore('ruby', 'keyword', {
+  'regex': {
+    pattern: /(^|[^/])\/(?!\/)(\[.+?]|\\.|[^/\r\n])+\/[gim]{0,3}(?=\s*($|[\r\n,.;})]))/g,
+    lookbehind: true
+  },
+  'variable': /[@$]+\b[a-zA-Z_][a-zA-Z_0-9]*[?!]?\b/g,
+  'symbol': /:\b[a-zA-Z_][a-zA-Z_0-9]*[?!]?\b/g
+});
+;
+Prism.languages.scala = Prism.languages.extend('java', {
+  'keyword': /(<-|=>)|\b(abstract|case|catch|class|def|do|else|extends|final|finally|for|forSome|if|implicit|import|lazy|match|new|null|object|override|package|private|protected|return|sealed|self|super|this|throw|trait|try|type|val|var|while|with|yield)\b/g,
+  'builtin': /\b(String|Int|Long|Short|Byte|Boolean|Double|Float|Char|Any|AnyRef|AnyVal|Unit|Nothing)\b/g,
+  'number': /\b0x[\da-f]*\.?[\da-f\-]+\b|\b\d*\.?\d+[e]?[\d]*[dfl]?\b/gi,
+  'symbol': /'([^\d\s]\w*)/g,
+  'string': /(""")[\W\w]*?\1|("|\/)[\W\w]*?\2|('.')/g
+});
+delete Prism.languages.scala['class-name','function'];
+;
+Prism.languages.haskell= {
+  'comment': {
+    pattern: /(^|[^-!#$%*+=\?&@|~.:<>^\\])(--[^-!#$%*+=\?&@|~.:<>^\\].*(\r?\n|$)|{-[\w\W]*?-})/gm,
+    lookbehind: true
+  },
+  'char': /'([^\\"]|\\([abfnrtv\\"'&]|\^[A-Z@[\]\^_]|NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|\d+|o[0-7]+|x[0-9a-fA-F]+))'/g,
+  'string': /"([^\\"]|\\([abfnrtv\\"'&]|\^[A-Z@[\]\^_]|NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|\d+|o[0-7]+|x[0-9a-fA-F]+)|\\\s+\\)*"/g,
+  'keyword' : /\b(case|class|data|deriving|do|else|if|in|infixl|infixr|instance|let|module|newtype|of|primitive|then|type|where)\b/g,
+  'import_statement' : {
+    // The imported or hidden names are not included in this import
+    // statement. This is because we want to highlight those exactly like
+    // we do for the names in the program.
+    pattern: /(\n|^)\s*(import)\s+(qualified\s+)?(([A-Z][_a-zA-Z0-9']*)(\.[A-Z][_a-zA-Z0-9']*)*)(\s+(as)\s+(([A-Z][_a-zA-Z0-9']*)(\.[A-Z][_a-zA-Z0-9']*)*))?(\s+hiding\b)?/gm,
+    inside: {
+      'keyword': /\b(import|qualified|as|hiding)\b/g
+    }
+  },
+  // These are builtin variables only. Constructors are highlighted later as a constant.
+  'builtin': /\b(abs|acos|acosh|all|and|any|appendFile|approxRational|asTypeOf|asin|asinh|atan|atan2|atanh|basicIORun|break|catch|ceiling|chr|compare|concat|concatMap|const|cos|cosh|curry|cycle|decodeFloat|denominator|digitToInt|div|divMod|drop|dropWhile|either|elem|encodeFloat|enumFrom|enumFromThen|enumFromThenTo|enumFromTo|error|even|exp|exponent|fail|filter|flip|floatDigits|floatRadix|floatRange|floor|fmap|foldl|foldl1|foldr|foldr1|fromDouble|fromEnum|fromInt|fromInteger|fromIntegral|fromRational|fst|gcd|getChar|getContents|getLine|group|head|id|inRange|index|init|intToDigit|interact|ioError|isAlpha|isAlphaNum|isAscii|isControl|isDenormalized|isDigit|isHexDigit|isIEEE|isInfinite|isLower|isNaN|isNegativeZero|isOctDigit|isPrint|isSpace|isUpper|iterate|last|lcm|length|lex|lexDigits|lexLitChar|lines|log|logBase|lookup|map|mapM|mapM_|max|maxBound|maximum|maybe|min|minBound|minimum|mod|negate|not|notElem|null|numerator|odd|or|ord|otherwise|pack|pi|pred|primExitWith|print|product|properFraction|putChar|putStr|putStrLn|quot|quotRem|range|rangeSize|read|readDec|readFile|readFloat|readHex|readIO|readInt|readList|readLitChar|readLn|readOct|readParen|readSigned|reads|readsPrec|realToFrac|recip|rem|repeat|replicate|return|reverse|round|scaleFloat|scanl|scanl1|scanr|scanr1|seq|sequence|sequence_|show|showChar|showInt|showList|showLitChar|showParen|showSigned|showString|shows|showsPrec|significand|signum|sin|sinh|snd|sort|span|splitAt|sqrt|subtract|succ|sum|tail|take|takeWhile|tan|tanh|threadToIOResult|toEnum|toInt|toInteger|toLower|toRational|toUpper|truncate|uncurry|undefined|unlines|until|unwords|unzip|unzip3|userError|words|writeFile|zip|zip3|zipWith|zipWith3)\b/g,
+  // decimal integers and floating point numbers | octal integers | hexadecimal integers
+  'number' : /\b(\d+(\.\d+)?([eE][+-]?\d+)?|0[Oo][0-7]+|0[Xx][0-9a-fA-F]+)\b/g,
+  // Most of this is needed because of the meaning of a single '.'.
+  // If it stands alone freely, it is the function composition.
+  // It may also be a separator between a module name and an identifier => no
+  // operator. If it comes together with other special characters it is an
+  // operator too.
+  'operator' : /\s\.\s|([-!#$%*+=\?&@|~:<>^\\]*\.[-!#$%*+=\?&@|~:<>^\\]+)|([-!#$%*+=\?&@|~:<>^\\]+\.[-!#$%*+=\?&@|~:<>^\\]*)|[-!#$%*+=\?&@|~:<>^\\]+|(`([A-Z][_a-zA-Z0-9']*\.)*[_a-z][_a-zA-Z0-9']*`)/g,
+  // In Haskell, nearly everything is a variable, do not highlight these.
+  'hvariable': /\b([A-Z][_a-zA-Z0-9']*\.)*[_a-z][_a-zA-Z0-9']*\b/g,
+  'constant': /\b([A-Z][_a-zA-Z0-9']*\.)*[A-Z][_a-zA-Z0-9']*\b/g,
+  'punctuation' : /[{}[\];(),.:]/g
+};
+;
+// issues: nested multiline comments, highlighting inside string interpolations
+Prism.languages.swift = Prism.languages.extend('clike', {
+  'keyword': /\b(as|associativity|break|case|class|continue|convenience|default|deinit|didSet|do|dynamicType|else|enum|extension|fallthrough|final|for|func|get|if|import|in|infix|init|inout|internal|is|lazy|left|let|mutating|new|none|nonmutating|operator|optional|override|postfix|precedence|prefix|private|protocol|public|required|return|right|safe|self|Self|set|static|struct|subscript|super|switch|Type|typealias|unowned|unowned|unsafe|var|weak|where|while|willSet|__COLUMN__|__FILE__|__FUNCTION__|__LINE__)\b/g,
+  'number': /\b([\d_]+(\.[\de_]+)?|0x[a-f0-9_]+(\.[a-f0-9p_]+)?|0b[01_]+|0o[0-7_]+)\b/gi,
+  'constant': /\b(nil|[A-Z_]{2,}|k[A-Z][A-Za-z_]+)\b/g,
+  'atrule': /\@\b(IBOutlet|IBDesignable|IBAction|IBInspectable|class_protocol|exported|noreturn|NSCopying|NSManaged|objc|UIApplicationMain|auto_closure)\b/g,
+  'builtin': /\b([A-Z]\S+|abs|advance|alignof|alignofValue|assert|contains|count|countElements|debugPrint|debugPrintln|distance|dropFirst|dropLast|dump|enumerate|equal|filter|find|first|getVaList|indices|isEmpty|join|last|lazy|lexicographicalCompare|map|max|maxElement|min|minElement|numericCast|overlaps|partition|prefix|print|println|reduce|reflect|reverse|sizeof|sizeofValue|sort|sorted|split|startsWith|stride|strideof|strideofValue|suffix|swap|toDebugString|toString|transcode|underestimateCount|unsafeBitCast|withExtendedLifetime|withUnsafeMutablePointer|withUnsafeMutablePointers|withUnsafePointer|withUnsafePointers|withVaList)\b/g
+});
+;
+Prism.languages.objectivec = Prism.languages.extend('c', {
+  'keyword': /(\b(asm|typeof|inline|auto|break|case|char|const|continue|default|do|double|else|enum|extern|float|for|goto|if|int|long|register|return|short|signed|sizeof|static|struct|switch|typedef|union|unsigned|void|volatile|while|in|self|super)\b)|((?=[\w|@])(@interface|@end|@implementation|@protocol|@class|@public|@protected|@private|@property|@try|@catch|@finally|@throw|@synthesize|@dynamic|@selector)\b)/g,
+  'string': /(?:("|')([^\n\\\1]|\\.|\\\r*\n)*?\1)|(@"([^\n\\"]|\\.|\\\r*\n)*?")/g,
+  'operator': /[-+]{1,2}|!=?|<{1,2}=?|>{1,2}=?|\->|={1,2}|\^|~|%|&{1,2}|\|?\||\?|\*|\/|@/g
+});
+;
+Prism.languages.latex = {
+  'comment': /%.*?(\r?\n|$)$/m,
+  'string': /(\$)(\\?.)*?\1/g,
+  'punctuation': /[{}]/g,
+  'selector': /\\[a-z;,:\.]*/i
+};
+Prism.languages.apacheconf = {
+  'comment': /\#.*/g,
+  'directive-inline': {
+    pattern: /^\s*\b(AcceptFilter|AcceptPathInfo|AccessFileName|Action|AddAlt|AddAltByEncoding|AddAltByType|AddCharset|AddDefaultCharset|AddDescription|AddEncoding|AddHandler|AddIcon|AddIconByEncoding|AddIconByType|AddInputFilter|AddLanguage|AddModuleInfo|AddOutputFilter|AddOutputFilterByType|AddType|Alias|AliasMatch|Allow|AllowCONNECT|AllowEncodedSlashes|AllowMethods|AllowOverride|AllowOverrideList|Anonymous|Anonymous_LogEmail|Anonymous_MustGiveEmail|Anonymous_NoUserID|Anonymous_VerifyEmail|AsyncRequestWorkerFactor|AuthBasicAuthoritative|AuthBasicFake|AuthBasicProvider|AuthBasicUseDigestAlgorithm|AuthDBDUserPWQuery|AuthDBDUserRealmQuery|AuthDBMGroupFile|AuthDBMType|AuthDBMUserFile|AuthDigestAlgorithm|AuthDigestDomain|AuthDigestNonceLifetime|AuthDigestProvider|AuthDigestQop|AuthDigestShmemSize|AuthFormAuthoritative|AuthFormBody|AuthFormDisableNoStore|AuthFormFakeBasicAuth|AuthFormLocation|AuthFormLoginRequiredLocation|AuthFormLoginSuccessLocation|AuthFormLogoutLocation|AuthFormMethod|AuthFormMimetype|AuthFormPassword|AuthFormProvider|AuthFormSitePassphrase|AuthFormSize|AuthFormUsername|AuthGroupFile|AuthLDAPAuthorizePrefix|AuthLDAPBindAuthoritative|AuthLDAPBindDN|AuthLDAPBindPassword|AuthLDAPCharsetConfig|AuthLDAPCompareAsUser|AuthLDAPCompareDNOnServer|AuthLDAPDereferenceAliases|AuthLDAPGroupAttribute|AuthLDAPGroupAttributeIsDN|AuthLDAPInitialBindAsUser|AuthLDAPInitialBindPattern|AuthLDAPMaxSubGroupDepth|AuthLDAPRemoteUserAttribute|AuthLDAPRemoteUserIsDN|AuthLDAPSearchAsUser|AuthLDAPSubGroupAttribute|AuthLDAPSubGroupClass|AuthLDAPUrl|AuthMerging|AuthName|AuthnCacheContext|AuthnCacheEnable|AuthnCacheProvideFor|AuthnCacheSOCache|AuthnCacheTimeout|AuthnzFcgiCheckAuthnProvider|AuthnzFcgiDefineProvider|AuthType|AuthUserFile|AuthzDBDLoginToReferer|AuthzDBDQuery|AuthzDBDRedirectQuery|AuthzDBMType|AuthzSendForbiddenOnFailure|BalancerGrowth|BalancerInherit|BalancerMember|BalancerPersist|BrowserMatch|BrowserMatchNoCase|BufferedLogs|BufferSize|CacheDefaultExpire|CacheDetailHeader|CacheDirLength|CacheDirLevels|CacheDisable|CacheEnable|CacheFile|CacheHeader|CacheIgnoreCacheControl|CacheIgnoreHeaders|CacheIgnoreNoLastMod|CacheIgnoreQueryString|CacheIgnoreURLSessionIdentifiers|CacheKeyBaseURL|CacheLastModifiedFactor|CacheLock|CacheLockMaxAge|CacheLockPath|CacheMaxExpire|CacheMaxFileSize|CacheMinExpire|CacheMinFileSize|CacheNegotiatedDocs|CacheQuickHandler|CacheReadSize|CacheReadTime|CacheRoot|CacheSocache|CacheSocacheMaxSize|CacheSocacheMaxTime|CacheSocacheMinTime|CacheSocacheReadSize|CacheSocacheReadTime|CacheStaleOnError|CacheStoreExpired|CacheStoreNoStore|CacheStorePrivate|CGIDScriptTimeout|CGIMapExtension|CharsetDefault|CharsetOptions|CharsetSourceEnc|CheckCaseOnly|CheckSpelling|ChrootDir|ContentDigest|CookieDomain|CookieExpires|CookieName|CookieStyle|CookieTracking|CoreDumpDirectory|CustomLog|Dav|DavDepthInfinity|DavGenericLockDB|DavLockDB|DavMinTimeout|DBDExptime|DBDInitSQL|DBDKeep|DBDMax|DBDMin|DBDParams|DBDPersist|DBDPrepareSQL|DBDriver|DefaultIcon|DefaultLanguage|DefaultRuntimeDir|DefaultType|Define|DeflateBufferSize|DeflateCompressionLevel|DeflateFilterNote|DeflateInflateLimitRequestBody|DeflateInflateRatioBurst|DeflateInflateRatioLimit|DeflateMemLevel|DeflateWindowSize|Deny|DirectoryCheckHandler|DirectoryIndex|DirectoryIndexRedirect|DirectorySlash|DocumentRoot|DTracePrivileges|DumpIOInput|DumpIOOutput|EnableExceptionHook|EnableMMAP|EnableSendfile|Error|ErrorDocument|ErrorLog|ErrorLogFormat|Example|ExpiresActive|ExpiresByType|ExpiresDefault|ExtendedStatus|ExtFilterDefine|ExtFilterOptions|FallbackResource|FileETag|FilterChain|FilterDeclare|FilterProtocol|FilterProvider|FilterTrace|ForceLanguagePriority|ForceType|ForensicLog|GprofDir|GracefulShutdownTimeout|Group|Header|HeaderName|HeartbeatAddress|HeartbeatListen|HeartbeatMaxServers|HeartbeatStorage|HeartbeatStorage|HostnameLookups|IdentityCheck|IdentityCheckTimeout|ImapBase|ImapDefault|ImapMenu|Include|IncludeOptional|IndexHeadInsert|IndexIgnore|IndexIgnoreReset|IndexOptions|IndexOrderDefault|IndexStyleSheet|InputSed|ISAPIAppendLogToErrors|ISAPIAppendLogToQuery|ISAPICacheFile|ISAPIFakeAsync|ISAPILogNotSupported|ISAPIReadAheadBuffer|KeepAlive|KeepAliveTimeout|KeptBodySize|LanguagePriority|LDAPCacheEntries|LDAPCacheTTL|LDAPConnectionPoolTTL|LDAPConnectionTimeout|LDAPLibraryDebug|LDAPOpCacheEntries|LDAPOpCacheTTL|LDAPReferralHopLimit|LDAPReferrals|LDAPRetries|LDAPRetryDelay|LDAPSharedCacheFile|LDAPSharedCacheSize|LDAPTimeout|LDAPTrustedClientCert|LDAPTrustedGlobalCert|LDAPTrustedMode|LDAPVerifyServerCert|LimitInternalRecursion|LimitRequestBody|LimitRequestFields|LimitRequestFieldSize|LimitRequestLine|LimitXMLRequestBody|Listen|ListenBackLog|LoadFile|LoadModule|LogFormat|LogLevel|LogMessage|LuaAuthzProvider|LuaCodeCache|LuaHookAccessChecker|LuaHookAuthChecker|LuaHookCheckUserID|LuaHookFixups|LuaHookInsertFilter|LuaHookLog|LuaHookMapToStorage|LuaHookTranslateName|LuaHookTypeChecker|LuaInherit|LuaInputFilter|LuaMapHandler|LuaOutputFilter|LuaPackageCPath|LuaPackagePath|LuaQuickHandler|LuaRoot|LuaScope|MaxConnectionsPerChild|MaxKeepAliveRequests|MaxMemFree|MaxRangeOverlaps|MaxRangeReversals|MaxRanges|MaxRequestWorkers|MaxSpareServers|MaxSpareThreads|MaxThreads|MergeTrailers|MetaDir|MetaFiles|MetaSuffix|MimeMagicFile|MinSpareServers|MinSpareThreads|MMapFile|ModemStandard|ModMimeUsePathInfo|MultiviewsMatch|Mutex|NameVirtualHost|NoProxy|NWSSLTrustedCerts|NWSSLUpgradeable|Options|Order|OutputSed|PassEnv|PidFile|PrivilegesMode|Protocol|ProtocolEcho|ProxyAddHeaders|ProxyBadHeader|ProxyBlock|ProxyDomain|ProxyErrorOverride|ProxyExpressDBMFile|ProxyExpressDBMType|ProxyExpressEnable|ProxyFtpDirCharset|ProxyFtpEscapeWildcards|ProxyFtpListOnWildcard|ProxyHTMLBufSize|ProxyHTMLCharsetOut|ProxyHTMLDocType|ProxyHTMLEnable|ProxyHTMLEvents|ProxyHTMLExtended|ProxyHTMLFixups|ProxyHTMLInterp|ProxyHTMLLinks|ProxyHTMLMeta|ProxyHTMLStripComments|ProxyHTMLURLMap|ProxyIOBufferSize|ProxyMaxForwards|ProxyPass|ProxyPassInherit|ProxyPassInterpolateEnv|ProxyPassMatch|ProxyPassReverse|ProxyPassReverseCookieDomain|ProxyPassReverseCookiePath|ProxyPreserveHost|ProxyReceiveBufferSize|ProxyRemote|ProxyRemoteMatch|ProxyRequests|ProxySCGIInternalRedirect|ProxySCGISendfile|ProxySet|ProxySourceAddress|ProxyStatus|ProxyTimeout|ProxyVia|ReadmeName|ReceiveBufferSize|Redirect|RedirectMatch|RedirectPermanent|RedirectTemp|ReflectorHeader|RemoteIPHeader|RemoteIPInternalProxy|RemoteIPInternalProxyList|RemoteIPProxiesHeader|RemoteIPTrustedProxy|RemoteIPTrustedProxyList|RemoveCharset|RemoveEncoding|RemoveHandler|RemoveInputFilter|RemoveLanguage|RemoveOutputFilter|RemoveType|RequestHeader|RequestReadTimeout|Require|RewriteBase|RewriteCond|RewriteEngine|RewriteMap|RewriteOptions|RewriteRule|RLimitCPU|RLimitMEM|RLimitNPROC|Satisfy|ScoreBoardFile|Script|ScriptAlias|ScriptAliasMatch|ScriptInterpreterSource|ScriptLog|ScriptLogBuffer|ScriptLogLength|ScriptSock|SecureListen|SeeRequestTail|SendBufferSize|ServerAdmin|ServerAlias|ServerLimit|ServerName|ServerPath|ServerRoot|ServerSignature|ServerTokens|Session|SessionCookieName|SessionCookieName2|SessionCookieRemove|SessionCryptoCipher|SessionCryptoDriver|SessionCryptoPassphrase|SessionCryptoPassphraseFile|SessionDBDCookieName|SessionDBDCookieName2|SessionDBDCookieRemove|SessionDBDDeleteLabel|SessionDBDInsertLabel|SessionDBDPerUser|SessionDBDSelectLabel|SessionDBDUpdateLabel|SessionEnv|SessionExclude|SessionHeader|SessionInclude|SessionMaxAge|SetEnv|SetEnvIf|SetEnvIfExpr|SetEnvIfNoCase|SetHandler|SetInputFilter|SetOutputFilter|SSIEndTag|SSIErrorMsg|SSIETag|SSILastModified|SSILegacyExprParser|SSIStartTag|SSITimeFormat|SSIUndefinedEcho|SSLCACertificateFile|SSLCACertificatePath|SSLCADNRequestFile|SSLCADNRequestPath|SSLCARevocationCheck|SSLCARevocationFile|SSLCARevocationPath|SSLCertificateChainFile|SSLCertificateFile|SSLCertificateKeyFile|SSLCipherSuite|SSLCompression|SSLCryptoDevice|SSLEngine|SSLFIPS|SSLHonorCipherOrder|SSLInsecureRenegotiation|SSLOCSPDefaultResponder|SSLOCSPEnable|SSLOCSPOverrideResponder|SSLOCSPResponderTimeout|SSLOCSPResponseMaxAge|SSLOCSPResponseTimeSkew|SSLOCSPUseRequestNonce|SSLOpenSSLConfCmd|SSLOptions|SSLPassPhraseDialog|SSLProtocol|SSLProxyCACertificateFile|SSLProxyCACertificatePath|SSLProxyCARevocationCheck|SSLProxyCARevocationFile|SSLProxyCARevocationPath|SSLProxyCheckPeerCN|SSLProxyCheckPeerExpire|SSLProxyCheckPeerName|SSLProxyCipherSuite|SSLProxyEngine|SSLProxyMachineCertificateChainFile|SSLProxyMachineCertificateFile|SSLProxyMachineCertificatePath|SSLProxyProtocol|SSLProxyVerify|SSLProxyVerifyDepth|SSLRandomSeed|SSLRenegBufferSize|SSLRequire|SSLRequireSSL|SSLSessionCache|SSLSessionCacheTimeout|SSLSessionTicketKeyFile|SSLSRPUnknownUserSeed|SSLSRPVerifierFile|SSLStaplingCache|SSLStaplingErrorCacheTimeout|SSLStaplingFakeTryLater|SSLStaplingForceURL|SSLStaplingResponderTimeout|SSLStaplingResponseMaxAge|SSLStaplingResponseTimeSkew|SSLStaplingReturnResponderErrors|SSLStaplingStandardCacheTimeout|SSLStrictSNIVHostCheck|SSLUserName|SSLUseStapling|SSLVerifyClient|SSLVerifyDepth|StartServers|StartThreads|Substitute|Suexec|SuexecUserGroup|ThreadLimit|ThreadsPerChild|ThreadStackSize|TimeOut|TraceEnable|TransferLog|TypesConfig|UnDefine|UndefMacro|UnsetEnv|Use|UseCanonicalName|UseCanonicalPhysicalPort|User|UserDir|VHostCGIMode|VHostCGIPrivs|VHostGroup|VHostPrivs|VHostSecure|VHostUser|VirtualDocumentRoot|VirtualDocumentRootIP|VirtualScriptAlias|VirtualScriptAliasIP|WatchdogInterval|XBitHack|xml2EncAlias|xml2EncDefault|xml2StartParse)\b/gmi,
+    alias: 'property'
+  },
+  'directive-block': {
+    pattern: /<\/?\b(AuthnProviderAlias|AuthzProviderAlias|Directory|DirectoryMatch|Else|ElseIf|Files|FilesMatch|If|IfDefine|IfModule|IfVersion|Limit|LimitExcept|Location|LocationMatch|Macro|Proxy|RequireAll|RequireAny|RequireNone|VirtualHost)\b *.*>/gi,
+    inside: {
+      'directive-block': {
+        pattern: /^<\/?\w+/,
+        inside: {
+          'punctuation': /^<\/?/
+        },
+        alias: 'tag'
+      },
+      'directive-block-parameter': {
+        pattern: /.*[^>]/,
+        inside: {
+          'punctuation': /:/,
+          'string': {
+            pattern: /("|').*\1/g,
+            inside: {
+              'variable': /(\$|%)\{?(\w\.?(\+|\-|:)?)+\}?/g
+            }
+          }
+        },
+        alias: 'attr-value'
+      },
+      'punctuation': />/
+    },
+    alias: 'tag'
+  },
+  'directive-flags': {
+    pattern: /\[(\w,?)+\]/g,
+    alias: 'keyword'
+  },
+  'string': {
+    pattern: /("|').*\1/g,
+    inside: {
+      'variable': /(\$|%)\{?(\w\.?(\+|\-|:)?)+\}?/g
+    }
+  },
+  'variable': /(\$|%)\{?(\w\.?(\+|\-|:)?)+\}?/g,
+  'regex': /\^?.*\$|\^.*\$?/g
+};
+;
+Prism.languages.git = {
+  /*
+   * A simple one line comment like in a git status command
+   * For instance:
+   * $ git status
+   * # On branch infinite-scroll
+   * # Your branch and 'origin/sharedBranches/frontendTeam/infinite-scroll' have diverged,
+   * # and have 1 and 2 different commits each, respectively.
+   * nothing to commit (working directory clean)
+   */
+  'comment': /^#.*$/m,
+
+  /*
+   * a string (double and simple quote)
+   */
+  'string': /("|')(\\?.)*?\1/gm,
+
+  /*
+   * a git command. It starts with a random prompt finishing by a $, then "git" then some other parameters
+   * For instance:
+   * $ git add file.txt
+   */
+  'command': {
+    pattern: /^.*\$ git .*$/m,
+    inside: {
+      /*
+       * A git command can contain a parameter starting by a single or a double dash followed by a string
+       * For instance:
+       * $ git diff --cached
+       * $ git log -p
+       */
+      'parameter': /\s(--|-)\w+/m
+    }
+  },
+
+  /*
+   * Coordinates displayed in a git diff command
+   * For instance:
+   * $ git diff
+   * diff --git file.txt file.txt
+   * index 6214953..1d54a52 100644
+   * --- file.txt
+   * +++ file.txt
+   * @@ -1 +1,2 @@
+   * -Here's my tetx file
+   * +Here's my text file
+   * +And this is the second line
+   */
+  'coord': /^@@.*@@$/m,
+
+  /*
+   * Regexp to match the changed lines in a git diff output. Check the example above.
+   */
+  'deleted': /^-(?!-).+$/m,
+  'inserted': /^\+(?!\+).+$/m,
+
+  /*
+   * Match a "commit [SHA1]" line in a git log output.
+   * For instance:
+   * $ git log
+   * commit a11a14ef7e26f2ca62d4b35eac455ce636d0dc09
+   * Author: lgiraudel
+   * Date:   Mon Feb 17 11:18:34 2014 +0100
+   *
+   *     Add of a new line
+   */
+  'commit_sha1': /^commit \w{40}$/m
+};
+;

--- a/vendor/assets/stylesheets/_prism.css
+++ b/vendor/assets/stylesheets/_prism.css
@@ -1,0 +1,132 @@
+/* http://prismjs.com/download.html?themes=prism&languages=markup+css+css-extras+clike+javascript+java+php+php-extras+coffeescript+scss+bash+c+python+sql+http+ruby+scala+haskell+swift+objectivec+latex+apacheconf+git */
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+  color: black;
+  text-shadow: 0 1px white;
+  font-family: Consolas, Monaco, 'Andale Mono', monospace;
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+  text-shadow: none;
+  background: #b3d4fc;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+  text-shadow: none;
+  background: #b3d4fc;
+}
+
+@media print {
+  code[class*="language-"],
+  pre[class*="language-"] {
+    text-shadow: none;
+  }
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+  padding: 1em;
+  margin: .5em 0;
+  overflow: auto;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  background: #f5f2f0;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+  padding: .1em;
+  border-radius: .3em;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: slategray;
+}
+
+.token.punctuation {
+  color: #999;
+}
+
+.namespace {
+  opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #905;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #690;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #a67f59;
+  background: hsla(0, 0%, 100%, .5);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #07a;
+}
+
+.token.function {
+  color: #DD4A68;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #e90;
+}
+
+.token.important {
+  font-weight: bold;
+}
+
+.token.entity {
+  cursor: help;
+}


### PR DESCRIPTION
[Trello](https://trello.com/c/ykiHQSqY/2178-markdown-interpreter-not-processing-code-spans-correctly) - [Platform](https://github.com/challengepost/platform/pull/2107)

---

Add [prism](http://prismjs.com/) to reimagine
