### PR TITLE
Fix main Navbar issue breaking at a certain screen size

### DIFF
--- a/app/assets/stylesheets/reimagine2/devpost/_global_nav_bar.sass
+++ b/app/assets/stylesheets/reimagine2/devpost/_global_nav_bar.sass
@@ -157,6 +157,9 @@
       strong
         display: inline
 
+      @media only screen and (max-width: 1068px)
+        padding: 0 1em
+
   .alpha
     display: none
     letter-spacing: 1px

--- a/app/assets/stylesheets/reimagine2/devpost/_global_nav_bar.sass
+++ b/app/assets/stylesheets/reimagine2/devpost/_global_nav_bar.sass
@@ -157,7 +157,7 @@
       strong
         display: inline
 
-      @media only screen and (max-width: 1068px)
+      @media only screen and (max-width: 1076px)
         padding: 0 1em
 
   .alpha

--- a/app/assets/stylesheets/reimagine2/devpost/_global_nav_bar.sass
+++ b/app/assets/stylesheets/reimagine2/devpost/_global_nav_bar.sass
@@ -158,7 +158,7 @@
         display: inline
 
       @media only screen and (max-width: 1076px)
-        padding: 0 1em
+        padding: 0 1.18em
 
   .alpha
     display: none

--- a/app/views/reimagine2/devpost/global_nav/_world_menu_entries.html.erb
+++ b/app/views/reimagine2/devpost/global_nav/_world_menu_entries.html.erb
@@ -37,6 +37,7 @@
     </li>
   </ul>
 </li>
+<li class="divider"></li>
 <li>
   <%= link_to reimagine_root_url(path: '/hackathons'), class: 'main-link', data: { role: 'discover' } do %>
     Hackathons


### PR DESCRIPTION
## Problem
The navbar starts to break at the `1076px` screen size and below.

## Workaround
- Reduce the padding between links in the navbar when the screen size is under `1076px` to make all the elements fit.
- Make sure it works for the different elements shown when the user is logged in and logged out.

## Result 

> User logged out

![platform-navbar-break-fix-logged-out](https://github.com/challengepost/reimagine/assets/13169164/86cef83e-b618-44ba-8cf5-f1599729fc2d)

> User logged in

![platform-navbar-break-fix-logged-in](https://github.com/challengepost/reimagine/assets/13169164/6a948236-39fd-414d-b6b5-80b71630bb5d)

