### PR TITLE
Fix platform_url to use configured root_host instead of hardcoded domains

### DIFF
--- a/app/helpers/reimagine2/url_helper.rb
+++ b/app/helpers/reimagine2/url_helper.rb
@@ -18,22 +18,7 @@ module Reimagine2
     end
 
     def platform_url(**args)
-      URI::HTTPS.build(**args.merge({ host: current_env_host })).to_s
-    end
-
-    private
-
-    def current_env_host
-      hosts = {
-        development: "devpost.dev",
-        staging: "staging.devpost.com",
-        test: "lvh.me",
-        production: "devpost.com"
-      }
-
-      environment = Rails.env.to_sym
-
-      return hosts[environment]
+      URI::HTTPS.build(**args.merge({ host: Reimagine2.configuration.root_host })).to_s
     end
 
   end

--- a/app/views/reimagine2/devpost/_footer.html.erb
+++ b/app/views/reimagine2/devpost/_footer.html.erb
@@ -16,8 +16,8 @@
       <nav>
         <h4>Hackathons</h4>
         <ul>
-          <li><a href="https://devpost.com/hackathons">Browse hackathons</a></li>
-          <li><a href="https://devpost.com/software">Explore projects</a></li>
+          <li><%= link_to "Browse hackathons", platform_url(path: '/hackathons') %></li>
+          <li><%= link_to "Explore projects", platform_url(path: '/software') %></li>
           <li><a href="https://info.devpost.com">Host a hackathon</a></li>
           <li><a href="https://info.devpost.com/guides">Hackathon guides</a></li>
         </ul>


### PR DESCRIPTION
The platform_url helper was using hardcoded domain mappings (e.g., devpost.dev for development) instead of using Reimagine2.configuration.root_host like the other URL helpers. This caused footer links like "Your projects" to point to the wrong domain in development environments.